### PR TITLE
Add documentation and expanded tests for rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ npx gh-pr-metrics octocat/hello-world --since 30d
 ```
 
 See the [metric reference](docs/metric-reference.md) for details.
+Documentation for the optional request throttling helper is available in
+[docs/rate-limiter.md](docs/rate-limiter.md).
 
 ## Development
 

--- a/docs/rate-limiter.md
+++ b/docs/rate-limiter.md
@@ -1,0 +1,19 @@
+# Rate Limiter
+
+The library exposes a small utility called `createRateLimiter` to help
+pace requests to the GitHub API. Internally it wraps a [Bottleneck](https://github.com/SGrondin/bottleneck)
+instance and schedules work so that no more than a fixed number of
+operations are executed per minute.
+
+```ts
+import { createRateLimiter } from '@gh-pr-metrics/core'
+
+// allow 60 requests each minute
+const limit = createRateLimiter({ requestsPerMinute: 60 })
+
+// schedule API calls
+await limit(() => fetch('https://api.github.com/'))
+```
+
+If no `requestsPerMinute` value is provided the limiter defaults to the
+standard GitHub API throughput of roughly 5000 requests per hour.

--- a/src/api/rateLimiter.ts
+++ b/src/api/rateLimiter.ts
@@ -1,5 +1,31 @@
-export function createRateLimiter(): void {
-  // TODO: implement rate limiting
+import Bottleneck from "bottleneck";
+
+export interface RateLimiterOptions {
+  /** Requests allowed per minute */
+  requestsPerMinute?: number;
+}
+
+/**
+ * Create a simple rate limiter using a token bucket. The returned
+ * function schedules work through a `Bottleneck` instance so that the
+ * given requests-per-minute limit is respected.
+ *
+ * @param opts - throttling options
+ * @returns a scheduler function wrapping `Bottleneck.schedule`
+ */
+export function createRateLimiter(
+  opts: RateLimiterOptions = {},
+): <T>(fn: () => Promise<T>) => Promise<T> {
+  const rpm = opts.requestsPerMinute ?? 5000 / 60;
+
+  const limiter = new Bottleneck({
+    reservoir: rpm,
+    reservoirRefreshAmount: rpm,
+    reservoirRefreshInterval: 60 * 1000,
+  });
+
+  return async <T>(fn: () => Promise<T>): Promise<T> =>
+    limiter.schedule(() => fn());
 }
 
 export default createRateLimiter;

--- a/test/rateLimiter.test.ts
+++ b/test/rateLimiter.test.ts
@@ -1,0 +1,47 @@
+import Bottleneck from "bottleneck";
+import { createRateLimiter } from "../src/api/rateLimiter";
+
+jest.mock("bottleneck", () => {
+  const Mock = jest.fn().mockImplementation(function (this: any, opts: any) {
+    this.opts = opts;
+    this.schedule = jest.fn(async (fn: any, ...args: any[]) => fn(...args));
+  });
+  return { __esModule: true, default: Mock };
+});
+
+describe("createRateLimiter", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("schedules functions through Bottleneck", async () => {
+    const limit = createRateLimiter({ requestsPerMinute: 10 });
+    const BottleneckMock = Bottleneck as unknown as jest.MockedClass<any>;
+    const instance = BottleneckMock.mock.instances[0];
+
+    const result = await limit(() => Promise.resolve("ok"));
+    expect(result).toBe("ok");
+    expect(instance.schedule).toHaveBeenCalledTimes(1);
+    expect(instance.opts.reservoir).toBe(10);
+  });
+
+  it("uses the default GitHub rate when no options are given", async () => {
+    const limit = createRateLimiter();
+    const BottleneckMock = Bottleneck as unknown as jest.MockedClass<any>;
+    const instance = BottleneckMock.mock.instances[0];
+
+    await limit(() => Promise.resolve());
+    expect(instance.opts.reservoir).toBeCloseTo(5000 / 60);
+  });
+
+  it("queues multiple tasks", async () => {
+    const limit = createRateLimiter({ requestsPerMinute: 2 });
+    const BottleneckMock = Bottleneck as unknown as jest.MockedClass<any>;
+    const instance = BottleneckMock.mock.instances[0];
+
+    await limit(() => Promise.resolve("a"));
+    await limit(() => Promise.resolve("b"));
+
+    expect(instance.schedule).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- document new rate limiter helper
- link documentation from README
- add more unit tests verifying default behavior and queuing

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684b68fc06e8833096f38aa9083360d9