### PR TITLE
Implement output writer

### DIFF
--- a/docs/write-output.md
+++ b/docs/write-output.md
@@ -1,0 +1,26 @@
+# Writing Output
+
+Use the `writeOutput` helper to write calculated metrics in different formats.
+
+```
+writeOutput(metrics, options?)
+```
+
+- `metrics` – Object containing the metrics you generated.
+- `options.format` – Either `"json"` or `"csv"`. Defaults to `json`.
+- `options.destination` – Where to send the output. You can pass a
+  file path, `"stdout"`, `"stderr"`, or a writable stream. Defaults to
+  `stdout`.
+
+Example:
+
+```ts
+import { writeOutput } from '@gh-pr-metrics/core';
+
+writeOutput(metrics, { format: 'csv', destination: 'metrics.csv' });
+writeOutput(metrics, { destination: 'stderr' });
+```
+
+When the destination is a writable stream, the output is written
+synchronously using the stream's `write` method.
+

--- a/src/output/writers.ts
+++ b/src/output/writers.ts
@@ -1,5 +1,64 @@
-export function writeOutput(): void {
-  // TODO: implement output writers
+import fs from "fs";
+import { Writable } from "stream";
+
+export interface OutputMetrics {
+  cycleTime: { median: number | null; p95: number | null };
+  pickupTime: { median: number | null; p95: number | null };
+}
+
+export interface WriteOutputOptions {
+  /** Output format. Defaults to `json`. */
+  format?: "json" | "csv";
+  /**
+   * Destination for the output. Can be a file path, `"stdout"`,
+   * `"stderr"`, or a writable stream instance. Defaults to `"stdout"`.
+   */
+  destination?: string | Writable;
+}
+
+/**
+ * Write metrics to a destination in either JSON or CSV format.
+ */
+export function writeOutput(
+  metrics: OutputMetrics,
+  opts: WriteOutputOptions = {},
+): void {
+  const format = opts.format ?? "json";
+  const { destination = "stdout" } = opts;
+
+  let output: string;
+  if (format === "csv") {
+    const rows = [
+      ["metric", "median", "p95"],
+      [
+        "cycleTime",
+        String(metrics.cycleTime.median ?? ""),
+        String(metrics.cycleTime.p95 ?? ""),
+      ],
+      [
+        "pickupTime",
+        String(metrics.pickupTime.median ?? ""),
+        String(metrics.pickupTime.p95 ?? ""),
+      ],
+    ];
+    output = rows.map((r) => r.join(",")).join("\n");
+  } else {
+    output = JSON.stringify(metrics, null, 2);
+  }
+
+  const finalOutput = output + "\n";
+
+  if (typeof destination === "string") {
+    if (destination === "stdout") {
+      process.stdout.write(finalOutput);
+    } else if (destination === "stderr") {
+      process.stderr.write(finalOutput);
+    } else {
+      fs.writeFileSync(destination, finalOutput);
+    }
+  } else if (destination instanceof Writable) {
+    destination.write(finalOutput);
+  }
 }
 
 export default writeOutput;

--- a/test/writeOutput.test.ts
+++ b/test/writeOutput.test.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Writable } from 'stream';
+import { writeOutput } from '../src/output/writers';
+
+describe('writeOutput', () => {
+  const metrics = {
+    cycleTime: { median: 1, p95: 2 },
+    pickupTime: { median: 3, p95: 4 },
+  };
+
+  it('writes JSON to provided stream', () => {
+    const chunks: string[] = [];
+    const stream = new Writable({
+      write(chunk, _enc, cb) {
+        chunks.push(String(chunk));
+        cb();
+      },
+    });
+    writeOutput(metrics, { destination: stream });
+    expect(chunks.join('')).toBe(JSON.stringify(metrics, null, 2) + '\n');
+  });
+
+  it('writes CSV to file', () => {
+    const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'out-')), 'metrics.csv');
+    writeOutput(metrics, { format: 'csv', destination: tmp });
+    const data = fs.readFileSync(tmp, 'utf8');
+    expect(data).toBe(
+      'metric,median,p95\ncycleTime,1,2\npickupTime,3,4\n'
+    );
+    fs.unlinkSync(tmp);
+  });
+
+  it('writes to stderr when requested', () => {
+    const spy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    writeOutput(metrics, { destination: 'stderr' });
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- flesh out `writeOutput` with format and destination options
- document `writeOutput` usage
- add unit tests
- document `writeOutput` function in docs
- revert README until further review

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684b69c07a3483309759b3e631ef5f0b