### PR TITLE
Add extended pull request metrics

### DIFF
--- a/docs/metric-reference.md
+++ b/docs/metric-reference.md
@@ -4,3 +4,13 @@
 | ------------ | ----------------------------------------- | ----- | -------------------------------------------------------------------------------------- |
 | `cycleTime`  | `(mergedAt - createdAt) / 3_600_000`      | hours | Measures total time from opening a PR until it is merged, highlighting delivery speed. |
 | `pickupTime` | `(firstReviewAt - createdAt) / 3_600_000` | hours | Shows how quickly reviewers start evaluating a PR, indicating responsiveness.          |
+| `mergeRate` | `merged PRs / total PRs` | ratio | Indicates what portion of submitted PRs ultimately merge. |
+| `closedWithoutMergeRate` | `closed without merge / total PRs` | ratio | Measures wasted or abandoned effort. |
+| `reviewCoverage` | `PRs with reviews / total PRs` | ratio | Ensures code changes are examined. |
+| `averageCommitsPerPr` | `total commits / total PRs` | count | Highlights churn within PRs. |
+| `outsizedPrs` | PR numbers exceeding threshold | list | Identifies overly large PRs that are hard to review. |
+| `buildSuccessRate` | `successful check suites / all check suites` | ratio | Captures CI stability. |
+| `averageCiDuration` | `sum(check duration) / count` | seconds | Average time CI takes to run. |
+| `stalePrCount` | count of open PRs not updated for > staleDays | count | Highlights neglected work. |
+| `hotfixFrequency` | `hotfix PRs / total PRs` | ratio | Shows urgency of production fixes. |
+| `prBacklog` | number of PRs still open | count | Indicates pipeline congestion. |

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ export default {
     "^\./calculators/cycleTime.js$": "<rootDir>/src/calculators/cycleTime.ts",
     "^\./calculators/reviewMetrics.js$":
       "<rootDir>/src/calculators/reviewMetrics.ts",
+    "^\./calculators/metrics.js$": "<rootDir>/src/calculators/metrics.ts",
   },
   globals: {
     "ts-jest": {

--- a/src/calculators/metrics.ts
+++ b/src/calculators/metrics.ts
@@ -32,7 +32,6 @@ export function calculateMetrics(
   let closedWithoutMerge = 0;
   let commitCount = 0;
   const outsizedPrs: number[] = [];
-  let reviewCountTotal = 0;
   let reviewedPrs = 0;
   let buildSuccess = 0;
   let checkSuiteCount = 0;
@@ -56,7 +55,6 @@ export function calculateMetrics(
     if (pr.reviews.length > 0) {
       reviewedPrs += 1;
       reviewCounts[pr.number] = pr.reviews.length;
-      reviewCountTotal += pr.reviews.length;
     }
 
     for (const cs of pr.checkSuites) {

--- a/src/calculators/metrics.ts
+++ b/src/calculators/metrics.ts
@@ -1,0 +1,103 @@
+export interface MetricsOptions {
+  outsizedThreshold?: number;
+  staleDays?: number;
+}
+
+import type { RawPullRequest } from "../collectors/pullRequests.js";
+
+export interface CalculatedMetrics {
+  prCountPerDeveloper: Record<string, number>;
+  mergeRate: number;
+  closedWithoutMergeRate: number;
+  averageCommitsPerPr: number;
+  outsizedPrs: number[];
+  reviewCoverage: number;
+  reviewCounts: Record<number, number>;
+  buildSuccessRate: number;
+  averageCiDuration: number;
+  stalePrCount: number;
+  hotfixFrequency: number;
+  prBacklog: number;
+}
+
+export function calculateMetrics(
+  prs: RawPullRequest[],
+  opts: MetricsOptions = {},
+): CalculatedMetrics {
+  const outsizedThreshold = opts.outsizedThreshold ?? 1000;
+  const staleDays = opts.staleDays ?? 30;
+
+  const prCountPerDeveloper: Record<string, number> = {};
+  let merged = 0;
+  let closedWithoutMerge = 0;
+  let commitCount = 0;
+  const outsizedPrs: number[] = [];
+  let reviewCountTotal = 0;
+  let reviewedPrs = 0;
+  let buildSuccess = 0;
+  let checkSuiteCount = 0;
+  let totalCiDuration = 0;
+  let stalePrCount = 0;
+  let hotfixCount = 0;
+  let prBacklog = 0;
+  const reviewCounts: Record<number, number> = {};
+
+  for (const pr of prs) {
+    if (pr.author?.login) {
+      prCountPerDeveloper[pr.author.login] =
+        (prCountPerDeveloper[pr.author.login] ?? 0) + 1;
+    }
+    if (pr.mergedAt) merged += 1;
+    if (!pr.mergedAt && pr.closedAt) closedWithoutMerge += 1;
+    commitCount += pr.commits.length;
+    const lines = pr.additions + pr.deletions;
+    if (lines > outsizedThreshold) outsizedPrs.push(pr.number);
+
+    if (pr.reviews.length > 0) {
+      reviewedPrs += 1;
+      reviewCounts[pr.number] = pr.reviews.length;
+      reviewCountTotal += pr.reviews.length;
+    }
+
+    for (const cs of pr.checkSuites) {
+      checkSuiteCount += 1;
+      if (cs.conclusion === "SUCCESS") buildSuccess += 1;
+      const start = Date.parse(cs.startedAt);
+      const end = Date.parse(cs.completedAt);
+      if (!Number.isNaN(start) && !Number.isNaN(end)) {
+        totalCiDuration += end - start;
+      }
+    }
+
+    if (pr.state === "OPEN") {
+      prBacklog += 1;
+      const updated = Date.parse(pr.updatedAt);
+      if (Date.now() - updated > staleDays * 86_400_000) {
+        stalePrCount += 1;
+      }
+    }
+
+    if (pr.labels.some((l) => /hotfix/i.test(l.name))) {
+      hotfixCount += 1;
+    }
+  }
+
+  return {
+    prCountPerDeveloper,
+    mergeRate: prs.length ? merged / prs.length : 0,
+    closedWithoutMergeRate: prs.length ? closedWithoutMerge / prs.length : 0,
+    averageCommitsPerPr: prs.length ? commitCount / prs.length : 0,
+    outsizedPrs,
+    reviewCoverage: prs.length ? reviewedPrs / prs.length : 0,
+    reviewCounts,
+    buildSuccessRate: checkSuiteCount ? buildSuccess / checkSuiteCount : 0,
+    averageCiDuration: checkSuiteCount
+      ? totalCiDuration / checkSuiteCount / 1000
+      : 0,
+    stalePrCount,
+    hotfixFrequency: prs.length ? hotfixCount / prs.length : 0,
+    prBacklog,
+  };
+}
+
+export default calculateMetrics;

--- a/src/collectors/pullRequests.ts
+++ b/src/collectors/pullRequests.ts
@@ -58,6 +58,10 @@ function mapPR(pr: any): RawPullRequest {
       startedAt: c.startedAt,
       completedAt: c.completedAt,
     })),
+    additions: pr.additions,
+    deletions: pr.deletions,
+    changedFiles: pr.changedFiles,
+    labels: pr.labels.nodes.map((l: any) => ({ name: l.name })),
   };
 }
 
@@ -72,7 +76,7 @@ export async function collectPullRequests(
   const prs: RawPullRequest[] = [];
   let cursor: string | null = null;
   let hasNextPage = true;
-  const query = `query($owner:String!,$repo:String!,$cursor:String){repository(owner:$owner,name:$repo){pullRequests(first:100,after:$cursor,orderBy:{field:UPDATED_AT,direction:DESC}){pageInfo{hasNextPage,endCursor}nodes{id number title state createdAt updatedAt mergedAt closedAt author{login}reviews(first:100){nodes{id state submittedAt author{login}}}comments(first:100){nodes{id body createdAt author{login}}}commits(last:100){nodes{commit{oid committedDate messageHeadline}}}checkSuites(first:100){nodes{id status conclusion startedAt completedAt}}}}}}`;
+  const query = `query($owner:String!,$repo:String!,$cursor:String){repository(owner:$owner,name:$repo){pullRequests(first:100,after:$cursor,orderBy:{field:UPDATED_AT,direction:DESC}){pageInfo{hasNextPage,endCursor}nodes{id number title state createdAt updatedAt mergedAt closedAt additions deletions changedFiles labels(first:20){nodes{name}} author{login}reviews(first:100){nodes{id state submittedAt author{login}}}comments(first:100){nodes{id body createdAt author{login}}}commits(last:100){nodes{commit{oid committedDate messageHeadline}}}checkSuites(first:100){nodes{id status conclusion startedAt completedAt}}}}}}`;
 
   let retries = 0;
   while (hasNextPage) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { collectPullRequests } from "./collectors/pullRequests.js";
 export { calculateCycleTime } from "./calculators/cycleTime.js";
 export { calculateReviewMetrics } from "./calculators/reviewMetrics.js";
+export { calculateMetrics } from "./calculators/metrics.js";
 export { runCli } from "./cli.js";

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -61,4 +61,12 @@ export interface PullRequest {
   comments: Comment[];
   commits: Commit[];
   checkSuites: CheckSuite[];
+  /** Lines added in the pull request */
+  additions: number;
+  /** Lines removed in the pull request */
+  deletions: number;
+  /** Number of files changed */
+  changedFiles: number;
+  /** Labels applied to the pull request */
+  labels: { name: string }[];
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -9,6 +9,10 @@ jest.mock("../src/collectors/pullRequests", () => ({
       updatedAt: "2024-01-02T00:00:00Z",
       mergedAt: "2024-01-02T00:00:00Z",
       closedAt: null,
+      additions: 1,
+      deletions: 1,
+      changedFiles: 1,
+      labels: [],
       author: null,
       reviews: [
         {

--- a/test/collectPullRequests.test.ts
+++ b/test/collectPullRequests.test.ts
@@ -43,6 +43,10 @@ describe("collectPullRequests", () => {
                   updatedAt: "2024-01-02T00:00:00Z",
                   mergedAt: null,
                   closedAt: null,
+                  additions: 5,
+                  deletions: 1,
+                  changedFiles: 2,
+                  labels: { nodes: [] },
                   author: { login: "a" },
                   reviews: { nodes: [] },
                   comments: { nodes: [] },
@@ -58,6 +62,10 @@ describe("collectPullRequests", () => {
                   updatedAt: "2024-01-03T00:00:00Z",
                   mergedAt: null,
                   closedAt: null,
+                  additions: 3,
+                  deletions: 2,
+                  changedFiles: 1,
+                  labels: { nodes: [] },
                   author: { login: "b" },
                   reviews: { nodes: [] },
                   comments: { nodes: [] },
@@ -85,6 +93,10 @@ describe("collectPullRequests", () => {
                   updatedAt: "2024-01-03T12:00:00Z",
                   mergedAt: null,
                   closedAt: null,
+                  additions: 4,
+                  deletions: 0,
+                  changedFiles: 1,
+                  labels: { nodes: [] },
                   author: { login: "c" },
                   reviews: { nodes: [] },
                   comments: { nodes: [] },
@@ -100,6 +112,10 @@ describe("collectPullRequests", () => {
                   updatedAt: "2023-12-31T00:00:00Z",
                   mergedAt: null,
                   closedAt: null,
+                  additions: 10,
+                  deletions: 5,
+                  changedFiles: 5,
+                  labels: { nodes: [] },
                   author: { login: "d" },
                   reviews: { nodes: [] },
                   comments: { nodes: [] },
@@ -121,6 +137,8 @@ describe("collectPullRequests", () => {
     });
 
     expect(prs.map((p) => p.id)).toEqual(["1", "2", "3"]);
+    expect(prs[0]?.additions).toBe(5);
+    expect(prs[1]?.labels).toEqual([]);
     scope.done();
   });
 });

--- a/test/cycleTime.test.ts
+++ b/test/cycleTime.test.ts
@@ -16,6 +16,10 @@ describe("calculateCycleTime", () => {
     comments: [],
     commits: [],
     checkSuites: [],
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    labels: [],
   };
 
   it("handles same-day merge", () => {

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -1,0 +1,44 @@
+import { calculateMetrics } from "../src/calculators/metrics";
+import { RawPullRequest } from "../src/collectors/pullRequests";
+
+describe("calculateMetrics", () => {
+  const base: RawPullRequest = {
+    id: "1",
+    number: 1,
+    title: "t",
+    state: "OPEN",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: new Date().toISOString(),
+    mergedAt: null,
+    closedAt: null,
+    author: { login: "a" },
+    reviews: [],
+    comments: [],
+    commits: [],
+    checkSuites: [],
+    additions: 5,
+    deletions: 0,
+    changedFiles: 1,
+    labels: [],
+  };
+
+  it("computes basic rates", () => {
+    const prs = [
+      { ...base, mergedAt: "2024-01-02T00:00:00Z" },
+      { ...base, number: 2, closedAt: "2024-01-03T00:00:00Z" },
+    ];
+
+    const m = calculateMetrics(prs);
+    expect(m.mergeRate).toBeCloseTo(0.5);
+    expect(m.closedWithoutMergeRate).toBeCloseTo(0.5);
+    expect(m.prCountPerDeveloper["a"]).toBe(2);
+  });
+
+  it("counts stale and hotfix PRs", () => {
+    const stale = { ...base, number: 3, updatedAt: "2024-01-01T00:00:00Z" };
+    stale.labels = [{ name: "hotfix" }];
+    const m = calculateMetrics([stale], { staleDays: 1 });
+    expect(m.stalePrCount).toBe(1);
+    expect(m.hotfixFrequency).toBe(1);
+  });
+});

--- a/test/reviewMetrics.test.ts
+++ b/test/reviewMetrics.test.ts
@@ -16,6 +16,10 @@ describe("calculateReviewMetrics", () => {
     comments: [],
     commits: [],
     checkSuites: [],
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    labels: [],
   };
 
   it("computes pickup time same day", () => {


### PR DESCRIPTION
## Summary
- collect additional PR fields like additions, deletions and labels
- expose new `calculateMetrics` helper for advanced metrics
- document new metrics in metric reference
- update Jest config and tests for new functionality

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b7baf4c208330a740b9234e61c505