### PR TITLE
Add CI metrics calculation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ export default {
     "^\./calculators/reviewMetrics.js$":
       "<rootDir>/src/calculators/reviewMetrics.ts",
     "^\./calculators/metrics.js$": "<rootDir>/src/calculators/metrics.ts",
+    "^\./calculators/ciMetrics.js$": "<rootDir>/src/calculators/ciMetrics.ts",
   },
   globals: {
     "ts-jest": {

--- a/src/calculators/ciMetrics.ts
+++ b/src/calculators/ciMetrics.ts
@@ -1,5 +1,37 @@
-export function calculateCiMetrics(): void {
-  // TODO: implement CI metrics calculation
+import type { RawPullRequest } from "../collectors/pullRequests.js";
+
+export interface CiMetrics {
+  /** Portion of check suites that completed successfully */
+  successRate: number;
+  /** Average duration of a check suite in seconds */
+  averageDuration: number;
+}
+
+/**
+ * Calculate CI related metrics for a pull request.
+ *
+ * @param pr - pull request record
+ * @returns CI metrics
+ */
+export function calculateCiMetrics(pr: RawPullRequest): CiMetrics {
+  let total = 0;
+  let success = 0;
+  let durationTotal = 0;
+
+  for (const suite of pr.checkSuites) {
+    total += 1;
+    if (suite.conclusion === "SUCCESS") success += 1;
+    const start = Date.parse(suite.startedAt);
+    const end = Date.parse(suite.completedAt);
+    if (!Number.isNaN(start) && !Number.isNaN(end)) {
+      durationTotal += end - start;
+    }
+  }
+
+  return {
+    successRate: total ? success / total : 0,
+    averageDuration: total ? durationTotal / total / 1000 : 0,
+  };
 }
 
 export default calculateCiMetrics;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export { collectPullRequests } from "./collectors/pullRequests.js";
 export { calculateCycleTime } from "./calculators/cycleTime.js";
 export { calculateReviewMetrics } from "./calculators/reviewMetrics.js";
 export { calculateMetrics } from "./calculators/metrics.js";
+export { calculateCiMetrics } from "./calculators/ciMetrics.js";
 export { runCli } from "./cli.js";

--- a/test/ciMetrics.test.ts
+++ b/test/ciMetrics.test.ts
@@ -1,0 +1,55 @@
+import { calculateCiMetrics } from "../src/calculators/ciMetrics";
+import { RawPullRequest } from "../src/collectors/pullRequests";
+
+describe("calculateCiMetrics", () => {
+  const base: RawPullRequest = {
+    id: "1",
+    number: 1,
+    title: "t",
+    state: "OPEN",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    mergedAt: null,
+    closedAt: null,
+    author: { login: "a" },
+    reviews: [],
+    comments: [],
+    commits: [],
+    checkSuites: [],
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    labels: [],
+  };
+
+  it("computes success rate and average duration", () => {
+    const pr = {
+      ...base,
+      checkSuites: [
+        {
+          id: "1",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+          startedAt: "2024-01-01T00:00:00Z",
+          completedAt: "2024-01-01T00:00:10Z",
+        },
+        {
+          id: "2",
+          status: "COMPLETED",
+          conclusion: "FAILURE",
+          startedAt: "2024-01-01T01:00:00Z",
+          completedAt: "2024-01-01T01:00:20Z",
+        },
+      ],
+    };
+    const m = calculateCiMetrics(pr);
+    expect(m.successRate).toBeCloseTo(0.5);
+    expect(m.averageDuration).toBeCloseTo(15);
+  });
+
+  it("handles absence of check suites", () => {
+    const m = calculateCiMetrics(base);
+    expect(m.successRate).toBe(0);
+    expect(m.averageDuration).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement success rate and average duration metrics in `calculateCiMetrics`
- export `calculateCiMetrics` from the package
- map ciMetrics module in Jest config
- add unit tests for CI metrics

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b872ca2648330b2729b3475f2638c