### PR TITLE
Use writeOutput helper in CLI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ export default {
       "<rootDir>/src/calculators/reviewMetrics.ts",
     "^\./calculators/metrics.js$": "<rootDir>/src/calculators/metrics.ts",
     "^\./calculators/ciMetrics.js$": "<rootDir>/src/calculators/ciMetrics.ts",
+    "^\./output/writers.js$": "<rootDir>/src/output/writers.ts",
   },
   globals: {
     "ts-jest": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import {
 } from "./collectors/pullRequests.js";
 import { calculateCycleTime } from "./calculators/cycleTime.js";
 import { calculateReviewMetrics } from "./calculators/reviewMetrics.js";
+import { writeOutput } from "./output/writers.js";
 
 interface CliOptions {
   since: string;
@@ -126,24 +127,7 @@ export async function runCli(argv = process.argv): Promise<void> {
     pickupTime: stats(pickupTimes),
   };
 
-  if (opts.format === "csv") {
-    const rows = [
-      ["metric", "median", "p95"],
-      [
-        "cycleTime",
-        String(result.cycleTime.median ?? ""),
-        String(result.cycleTime.p95 ?? ""),
-      ],
-      [
-        "pickupTime",
-        String(result.pickupTime.median ?? ""),
-        String(result.pickupTime.p95 ?? ""),
-      ],
-    ];
-    console.log(rows.map((r) => r.join(",")).join("\n"));
-  } else {
-    console.log(JSON.stringify(result, null, 2));
-  }
+  writeOutput(result, { format: opts.format as "json" | "csv" });
 }
 
 export default runCli;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -42,19 +42,23 @@ describe("cli", () => {
   const origArgv = process.argv;
   const log = jest.spyOn(console, "log").mockImplementation(() => {});
   const error = jest.spyOn(console, "error").mockImplementation(() => {});
+  const stdout = jest
+    .spyOn(process.stdout, "write")
+    .mockImplementation(() => true);
 
   afterEach(() => {
     process.argv = origArgv;
     log.mockClear();
     error.mockClear();
+    stdout.mockClear();
     jest.clearAllMocks();
   });
 
   it("prints JSON metrics", async () => {
     process.argv = ["node", "cli", "foo/bar", "--token", "t"];
     await runCli();
-    expect(log).toHaveBeenCalledTimes(1);
-    const firstCall = log.mock.calls[0]?.[0] as string;
+    expect(stdout).toHaveBeenCalledTimes(1);
+    const firstCall = stdout.mock.calls[0]?.[0] as string;
     const output = JSON.parse(firstCall);
     expect(output.cycleTime.median).toBe(10);
     expect(output.pickupTime.p95).toBe(20);


### PR DESCRIPTION
## Summary
- use `writeOutput` helper in `src/cli.ts`
- map writer file for ts-jest
- update CLI tests for new stdout behavior

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b88c0e51083309640fdb7ef3ba578