### PR TITLE
Add output option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ npx gh-pr-metrics <owner/repo> --since 30d --token YOUR_TOKEN \
   --base-url https://github.mycompany.com/api/v3 --progress
 ```
 
+To save the metrics to a file:
+
+```
+npx gh-pr-metrics <owner/repo> --format csv --token YOUR_TOKEN \
+  --output metrics.csv
+```
+
 Use `--dry-run` to check parameters without contacting GitHub. The `--base-url`
 option enables GitHub Enterprise support by pointing to the API root.
 Progress output is printed to stderr as pull requests are fetched.
+Set `--output <path|stdout|stderr>` to control where the metrics are written.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ interface CliOptions {
   baseUrl?: string;
   dryRun?: boolean;
   progress?: boolean;
+  output?: string;
 }
 
 function stats(values: number[]): {
@@ -51,6 +52,11 @@ export async function runCli(argv = process.argv): Promise<void> {
     .option("--base-url <url>", "GitHub API base URL")
     .option("--dry-run", "print options and exit")
     .option("--progress", "show progress during fetch")
+    .option(
+      "--output <path|stdout|stderr>",
+      "write metrics to file or stdout/stderr",
+      "stdout",
+    )
     .allowExcessArguments(false);
 
   program.parse(argv);
@@ -127,7 +133,10 @@ export async function runCli(argv = process.argv): Promise<void> {
     pickupTime: stats(pickupTimes),
   };
 
-  writeOutput(result, { format: opts.format as "json" | "csv" });
+  writeOutput(result, {
+    format: opts.format as "json" | "csv",
+    destination: opts.output,
+  });
 }
 
 export default runCli;


### PR DESCRIPTION
## Summary
- add `--output` option to CLI
- document new option and add example
- cover `--output` flag in tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b8a05cf848330b57ee6891ae54ed0