### PR TITLE
Add all-metrics CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Use `--dry-run` to check parameters without contacting GitHub. The `--base-url`
 option enables GitHub Enterprise support by pointing to the API root.
 Progress output is printed to stderr as pull requests are fetched.
 Set `--output <path|stdout|stderr>` to control where the metrics are written.
+Use `--all-metrics` to include additional repository metrics in the output.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import {
 } from "./collectors/pullRequests.js";
 import { calculateCycleTime } from "./calculators/cycleTime.js";
 import { calculateReviewMetrics } from "./calculators/reviewMetrics.js";
+import { calculateMetrics } from "./calculators/metrics.js";
 import { writeOutput } from "./output/writers.js";
 
 interface CliOptions {
@@ -19,6 +20,7 @@ interface CliOptions {
   dryRun?: boolean;
   progress?: boolean;
   output?: string;
+  allMetrics?: boolean;
 }
 
 function stats(values: number[]): {
@@ -52,6 +54,7 @@ export async function runCli(argv = process.argv): Promise<void> {
     .option("--base-url <url>", "GitHub API base URL")
     .option("--dry-run", "print options and exit")
     .option("--progress", "show progress during fetch")
+    .option("--all-metrics", "include additional metrics")
     .option(
       "--output <path|stdout|stderr>",
       "write metrics to file or stdout/stderr",
@@ -127,8 +130,10 @@ export async function runCli(argv = process.argv): Promise<void> {
       } catch {
         /* ignore */
       }
-    }
+  }
+  const extra = opts.allMetrics ? calculateMetrics(prs) : {};
   const result = {
+    ...extra,
     cycleTime: stats(cycleTimes),
     pickupTime: stats(pickupTimes),
   };

--- a/src/output/writers.ts
+++ b/src/output/writers.ts
@@ -4,6 +4,7 @@ import { Writable } from "stream";
 export interface OutputMetrics {
   cycleTime: { median: number | null; p95: number | null };
   pickupTime: { median: number | null; p95: number | null };
+  [key: string]: unknown;
 }
 
 export interface WriteOutputOptions {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -42,6 +42,9 @@ jest.mock("../src/calculators/cycleTime", () => ({
 jest.mock("../src/calculators/reviewMetrics", () => ({
   calculateReviewMetrics: jest.fn(() => 20),
 }));
+jest.mock("../src/calculators/metrics", () => ({
+  calculateMetrics: jest.fn(() => ({ mergeRate: 0.5 })),
+}));
 
 import fs from "fs";
 import os from "os";
@@ -121,5 +124,14 @@ describe("cli", () => {
     await runCli();
     expect(errSpy).toHaveBeenCalled();
     errSpy.mockRestore();
+  });
+
+  it("includes all metrics when requested", async () => {
+    const { runCli } = require("../src/cli");
+    process.argv = ["node", "cli", "foo/bar", "--token", "t", "--all-metrics"];
+    await runCli();
+    const firstCall = stdout.mock.calls[0]?.[0] as string;
+    const output = JSON.parse(firstCall);
+    expect(output.mergeRate).toBe(0.5);
   });
 });


### PR DESCRIPTION
## Summary
- support `--all-metrics` to calculate extra PR metrics
- include extra metrics in CLI output
- document the new flag
- test the new CLI behaviour

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b8f8f5c64833095636c9fb7e4126b