### PR TITLE
Add scoring normalization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,90 @@ before it is considered stale.
 
 See [docs/metric-reference.md](docs/metric-reference.md) for definitions of all
 available metrics.
+
+### `scoreMetrics`
+
+After calculating metrics you can derive a single numeric score by
+combining them with custom weights.
+
+```ts
+import { scoreMetrics } from '@gh-pr-metrics/core'
+
+const score = scoreMetrics(metrics, [
+  { weight: 0.6, metric: 'mergeRate' },
+  { weight: 0.4, metric: 'reviewCoverage' },
+])
+```
+
+Rules may also use custom functions to leverage any metric data:
+
+```ts
+const score = scoreMetrics(metrics, [
+  { weight: 1, metric: 'mergeRate' },
+  { weight: -0.1, fn: m => m.prBacklog },
+])
+```
+
+Metrics can be normalized before weighting using the `normalize` option. This
+is useful for converting ratios into a 1–100 scale:
+
+```ts
+const score = scoreMetrics(metrics, [
+  { weight: 0.5, metric: 'mergeRate', normalize: v => v * 100 },
+  { weight: 0.5, metric: 'reviewCoverage', normalize: v => v * 100 },
+])
+```
+
+More advanced transforms can convert ranges of values to discrete scores. The
+`createRangeNormalizer` helper makes this easy:
+
+```ts
+import { scoreMetrics, createRangeNormalizer } from '@gh-pr-metrics/core'
+
+const normalizePickupTime = createRangeNormalizer(
+  [
+    { max: 4, score: 100 },
+    { max: 6, score: 80 },
+    { max: 12, score: 60 },
+  ],
+  40,
+)
+
+const score = scoreMetrics({ pickupTime: 5 }, [
+  { weight: 1, metric: 'pickupTime', normalize: normalizePickupTime },
+])
+```
+
+You can reuse the normalizer alongside others for a combined score:
+
+```ts
+const metrics = { pickupTime: 2, mergeRate: 0.95 }
+
+const normalizePickupTime = createRangeNormalizer(
+  [
+    { max: 4, score: 100 },
+    { max: 6, score: 80 },
+    { max: 12, score: 60 },
+  ],
+  40,
+)
+
+const pct = (v: number) => Math.round(v * 100)
+
+const score = scoreMetrics(metrics, [
+  { weight: 0.5, metric: 'pickupTime', normalize: normalizePickupTime },
+  { weight: 0.5, metric: 'mergeRate', normalize: pct },
+])
+// => 98
+```
+
+Multiple rules can even target the same metric, for example to
+compare rounding strategies:
+
+```ts
+scoreMetrics({ mergeRate: 0.955 }, [
+  { weight: 0.5, metric: 'mergeRate', normalize: v => Math.floor(v * 100) },
+  { weight: 0.5, metric: 'mergeRate', normalize: v => Math.ceil(v * 100) },
+])
+// => 95.5
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export { calculateReviewMetrics } from "./calculators/reviewMetrics.js";
 export { calculateMetrics } from "./calculators/metrics.js";
 export { calculateCiMetrics } from "./calculators/ciMetrics.js";
 export { runCli } from "./cli.js";
+export { scoreMetrics } from "./scoring.js";
+export { createRangeNormalizer } from "./normalize.js";

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,0 +1,29 @@
+export interface RangeRule {
+  /** Exclusive upper bound for this range */
+  max: number;
+  /** Score returned when the value falls below `max` */
+  score: number;
+}
+
+/**
+ * Build a function that maps numeric values to scores based on ranges.
+ *
+ * Ranges are checked in order until `value < max` is met. If no range
+ * matches, `defaultScore` is returned.
+ */
+export function createRangeNormalizer(
+  ranges: RangeRule[],
+  defaultScore: number,
+): (value: number) => number {
+  const ordered = [...ranges].sort((a, b) => a.max - b.max);
+  return (value: number): number => {
+    for (const { max, score } of ordered) {
+      if (value < max) {
+        return score;
+      }
+    }
+    return defaultScore;
+  };
+}
+
+export default createRangeNormalizer;

--- a/src/scoring.ts
+++ b/src/scoring.ts
@@ -1,0 +1,47 @@
+export interface ScoreRule<Metrics> {
+  /** weight multiplier applied to the rule result */
+  weight: number;
+  /**
+   * Name of a numeric field on the metrics object. Ignored if `fn` is
+   * provided.
+   */
+  metric?: keyof Metrics;
+  /**
+   * Custom function returning a numeric value derived from the metrics.
+   */
+  fn?: (metrics: Metrics) => number;
+
+  /**
+   * Optional transform that converts the raw metric value into a score. This
+   * can be used to normalize values to a 1-100 range before weighting.
+   */
+  normalize?: (value: number, metrics: Metrics) => number;
+}
+
+/**
+ * Calculate a weighted score from a metrics object.
+ *
+ * Each rule contributes `weight * value` to the final score where the value is
+ * either read from the given metric field or returned from `fn`.
+ */
+export function scoreMetrics<Metrics extends Record<string, any>>(
+  metrics: Metrics,
+  rules: ScoreRule<Metrics>[],
+): number {
+  let score = 0;
+  for (const rule of rules) {
+    let value =
+      typeof rule.fn === "function"
+        ? rule.fn(metrics)
+        : (metrics as any)[rule.metric as string];
+    if (typeof value === "number" && !Number.isNaN(value)) {
+      if (typeof rule.normalize === "function") {
+        value = rule.normalize(value, metrics);
+      }
+      score += value * rule.weight;
+    }
+  }
+  return score;
+}
+
+export default scoreMetrics;

--- a/test/scoring.test.ts
+++ b/test/scoring.test.ts
@@ -1,0 +1,132 @@
+import { scoreMetrics, ScoreRule } from "../src/scoring";
+import { createRangeNormalizer } from "../src/normalize";
+import type { CalculatedMetrics } from "../src/calculators/metrics";
+
+describe("scoreMetrics", () => {
+  const metrics: CalculatedMetrics = {
+    prCountPerDeveloper: {},
+    mergeRate: 0.8,
+    closedWithoutMergeRate: 0.1,
+    averageCommitsPerPr: 2,
+    outsizedPrs: [],
+    reviewCoverage: 0.9,
+    reviewCounts: {},
+    buildSuccessRate: 1,
+    averageCiDuration: 50,
+    stalePrCount: 1,
+    hotfixFrequency: 0,
+    prBacklog: 3,
+  };
+
+  it("calculates weighted sum using metric names", () => {
+    const rules: ScoreRule<CalculatedMetrics>[] = [
+      { weight: 0.6, metric: "mergeRate" },
+      { weight: 0.4, metric: "reviewCoverage" },
+    ];
+    const score = scoreMetrics(metrics, rules);
+    expect(score).toBeCloseTo(0.84);
+  });
+
+  it("supports custom functions", () => {
+    const rules: ScoreRule<CalculatedMetrics>[] = [
+      { weight: 1, metric: "mergeRate" },
+      { weight: -0.1, fn: (m) => m.prBacklog },
+    ];
+    const score = scoreMetrics(metrics, rules);
+    expect(score).toBeCloseTo(0.8 - 0.3);
+  });
+
+  it("normalizes values before weighting", () => {
+    const rules: ScoreRule<CalculatedMetrics>[] = [
+      { weight: 0.5, metric: "mergeRate", normalize: (v) => v * 100 },
+      { weight: 0.5, metric: "reviewCoverage", normalize: (v) => v * 100 },
+    ];
+    const score = scoreMetrics(metrics, rules);
+    expect(score).toBeCloseTo(85);
+  });
+
+  it("maps review time ranges to scores", () => {
+    interface ReviewMetrics { pickupTime: number }
+    const review: ReviewMetrics = { pickupTime: 5 };
+    const normalize = createRangeNormalizer(
+      [
+        { max: 4, score: 100 },
+        { max: 6, score: 80 },
+        { max: 12, score: 60 },
+      ],
+      40,
+    );
+    const rules: ScoreRule<ReviewMetrics>[] = [
+      { weight: 1, metric: "pickupTime", normalize },
+    ];
+    const score = scoreMetrics(review, rules);
+    expect(score).toBe(80);
+  });
+});
+
+describe("createRangeNormalizer", () => {
+  it("applies thresholds in order", () => {
+    const normalize = createRangeNormalizer([
+      { max: 10, score: 50 },
+      { max: 20, score: 30 },
+    ], 0);
+    expect(normalize(5)).toBe(50);
+    expect(normalize(15)).toBe(30);
+    expect(normalize(25)).toBe(0);
+  });
+it("handles edge cases and decimals", () => {
+  const normalize = createRangeNormalizer(
+    [
+      { max: 4, score: 100 },
+      { max: 6, score: 80 },
+      { max: 12, score: 60 },
+    ],
+    40,
+  );
+  expect(normalize(-1)).toBe(100);
+  expect(normalize(0)).toBe(100);
+  expect(normalize(4)).toBe(80);
+  expect(normalize(6)).toBe(60);
+  expect(normalize(12)).toBe(40);
+  expect(normalize(5.5)).toBe(80);
+});
+
+it("supports rounding strategies on percentages", () => {
+  const floorNorm = (v: number) => Math.floor(v * 100);
+  const ceilNorm = (v: number) => Math.ceil(v * 100);
+  expect(floorNorm(0.955)).toBe(95);
+  expect(ceilNorm(0.955)).toBe(96);
+});
+
+it("aggregates multiple normalizers in scoring", () => {
+  const metrics = { pickupTime: 4.5, mergeRate: 0.92 };
+  const range = createRangeNormalizer(
+    [
+      { max: 4, score: 100 },
+      { max: 6, score: 80 },
+      { max: 12, score: 60 },
+    ],
+    40,
+  );
+  const percent = (v: number) => Math.round(v * 100);
+  const rules: ScoreRule<typeof metrics>[] = [
+    { weight: 0.5, metric: "pickupTime", normalize: range },
+    { weight: 0.5, metric: "mergeRate", normalize: percent },
+  ];
+  const score = scoreMetrics(metrics, rules);
+  expect(score).toBeCloseTo(86);
+});
+
+it("combines multiple rules for one metric", () => {
+  const metrics = { mergeRate: 0.955 };
+  const floor = (v: number) => Math.floor(v * 100);
+  const ceil = (v: number) => Math.ceil(v * 100);
+  const rules: ScoreRule<typeof metrics>[] = [
+    { weight: 0.5, metric: "mergeRate", normalize: floor },
+    { weight: 0.5, metric: "mergeRate", normalize: ceil },
+  ];
+  const score = scoreMetrics(metrics, rules);
+  expect(score).toBeCloseTo(95.5);
+});
+
+});


### PR DESCRIPTION
## Summary
- document advanced normalization ranges in README
- add `createRangeNormalizer` to simplify range-based scoring
- test conditional `normalize` function for scoring engine
- add more tests for range normalizer edge cases and combined usage

## Testing
- `pnpm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b921e5a088330845c5d6fbc507927