### PR TITLE
Add new metric calculators

### DIFF
--- a/src/calculators/changeRequestRatio.ts
+++ b/src/calculators/changeRequestRatio.ts
@@ -1,0 +1,23 @@
+import type { RawPullRequest } from "../collectors/pullRequests.js";
+
+/**
+ * Calculate the portion of reviews requesting changes.
+ *
+ * @param pr - pull request record
+ * @returns ratio of change requests to total reviews
+ * @throws if there are no reviews
+ */
+export function calculateChangeRequestRatio(pr: RawPullRequest): number {
+  if (!pr.reviews || pr.reviews.length === 0) {
+    throw new Error("No reviews to evaluate change request ratio");
+  }
+  let total = 0;
+  let requested = 0;
+  for (const review of pr.reviews) {
+    total += 1;
+    if (review.state === "CHANGES_REQUESTED") requested += 1;
+  }
+  return requested / total;
+}
+
+export default calculateChangeRequestRatio;

--- a/src/calculators/ciPassRate.ts
+++ b/src/calculators/ciPassRate.ts
@@ -1,0 +1,22 @@
+import type { RawPullRequest } from "../collectors/pullRequests.js";
+
+/**
+ * Calculate the portion of check suites that completed successfully.
+ *
+ * @param pr - pull request record
+ * @returns success rate of CI check suites
+ */
+export function calculateCiPassRate(pr: RawPullRequest): number {
+  if (!pr.checkSuites) {
+    throw new Error("Missing check suite data");
+  }
+  let total = 0;
+  let passed = 0;
+  for (const suite of pr.checkSuites) {
+    total += 1;
+    if (suite.conclusion === "SUCCESS") passed += 1;
+  }
+  return total ? passed / total : 0;
+}
+
+export default calculateCiPassRate;

--- a/src/calculators/commentDensity.ts
+++ b/src/calculators/commentDensity.ts
@@ -1,0 +1,18 @@
+import type { RawPullRequest } from "../collectors/pullRequests.js";
+
+/**
+ * Calculate comment density relative to lines changed.
+ *
+ * @param pr - pull request record
+ * @returns ratio of comments to total line changes
+ * @throws if there are no line changes
+ */
+export function calculateCommentDensity(pr: RawPullRequest): number {
+  const linesChanged = pr.additions + pr.deletions;
+  if (linesChanged === 0) {
+    throw new Error("No code changes to calculate comment density");
+  }
+  return pr.comments.length / linesChanged;
+}
+
+export default calculateCommentDensity;

--- a/src/calculators/idleTimeHours.ts
+++ b/src/calculators/idleTimeHours.ts
@@ -1,0 +1,48 @@
+import type { RawPullRequest } from "../collectors/pullRequests.js";
+
+/**
+ * Sum time exceeding 24h between PR activity events.
+ *
+ * @param pr - pull request record
+ * @returns idle time in hours rounded to one decimal
+ * @throws if required timestamps are missing
+ */
+export function calculateIdleTimeHours(pr: RawPullRequest): number {
+  if (!pr.createdAt) {
+    throw new Error("Missing createdAt timestamp");
+  }
+  const end = pr.mergedAt ?? pr.closedAt ?? pr.updatedAt;
+  if (!end) {
+    throw new Error("Missing end timestamp");
+  }
+  const startTime = Date.parse(pr.createdAt);
+  const endTime = Date.parse(end);
+  if (Number.isNaN(startTime) || Number.isNaN(endTime)) {
+    throw new Error("Invalid timestamp");
+  }
+  const eventTimes: number[] = [startTime];
+  for (const c of pr.commits) {
+    const t = Date.parse(c.committedDate);
+    if (!Number.isNaN(t)) eventTimes.push(t);
+  }
+  for (const r of pr.reviews) {
+    const t = Date.parse(r.submittedAt);
+    if (!Number.isNaN(t)) eventTimes.push(t);
+  }
+  eventTimes.sort((a, b) => a - b);
+  if (eventTimes[eventTimes.length - 1] !== endTime) {
+    eventTimes.push(endTime);
+  }
+  const dayMs = 86_400_000;
+  let idleMs = 0;
+  for (let i = 1; i < eventTimes.length; i += 1) {
+    const gap = eventTimes[i]! - eventTimes[i - 1]!;
+    if (gap > dayMs) {
+      idleMs += gap - dayMs;
+    }
+  }
+  const hours = idleMs / 3_600_000;
+  return Math.round(hours * 10) / 10;
+}
+
+export default calculateIdleTimeHours;

--- a/src/calculators/revertRate.ts
+++ b/src/calculators/revertRate.ts
@@ -1,0 +1,23 @@
+import type { RawPullRequest } from "../collectors/pullRequests.js";
+
+/**
+ * Determine the proportion of commits that are revert commits.
+ *
+ * @param pr - pull request record
+ * @returns ratio of revert commits
+ * @throws if commit data is missing
+ */
+export function calculateRevertRate(pr: RawPullRequest): number {
+  if (!pr.commits || pr.commits.length === 0) {
+    throw new Error("No commits to evaluate revert rate");
+  }
+  let total = 0;
+  let reverts = 0;
+  for (const commit of pr.commits) {
+    total += 1;
+    if (/\brevert\b/i.test(commit.messageHeadline)) reverts += 1;
+  }
+  return reverts / total;
+}
+
+export default calculateRevertRate;

--- a/src/calculators/reviewerCount.ts
+++ b/src/calculators/reviewerCount.ts
@@ -1,0 +1,23 @@
+import type { RawPullRequest } from "../collectors/pullRequests.js";
+
+/**
+ * Count unique reviewers on a pull request.
+ *
+ * @param pr - pull request record
+ * @returns number of distinct reviewers
+ * @throws if review data is missing
+ */
+export function calculateReviewerCount(pr: RawPullRequest): number {
+  if (!pr.reviews) {
+    throw new Error("Missing review data");
+  }
+  const reviewers = new Set<string>();
+  for (const review of pr.reviews) {
+    if (review.author?.login) {
+      reviewers.add(review.author.login);
+    }
+  }
+  return reviewers.size;
+}
+
+export default calculateReviewerCount;

--- a/src/calculators/sizeBucket.ts
+++ b/src/calculators/sizeBucket.ts
@@ -1,0 +1,16 @@
+import type { RawPullRequest } from "../collectors/pullRequests.js";
+
+/**
+ * Categorise pull request size by lines changed.
+ *
+ * @param pr - pull request record
+ * @returns "S", "M" or "L" size bucket
+ */
+export function calculateSizeBucket(pr: RawPullRequest): string {
+  const linesChanged = pr.additions + pr.deletions;
+  if (linesChanged < 50) return "S";
+  if (linesChanged < 400) return "M";
+  return "L";
+}
+
+export default calculateSizeBucket;

--- a/test/changeRequestRatio.test.ts
+++ b/test/changeRequestRatio.test.ts
@@ -1,0 +1,40 @@
+import { calculateChangeRequestRatio } from "../src/calculators/changeRequestRatio";
+import { RawPullRequest } from "../src/collectors/pullRequests";
+
+describe("calculateChangeRequestRatio", () => {
+  const base: RawPullRequest = {
+    id: "1",
+    number: 1,
+    title: "t",
+    state: "OPEN",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    mergedAt: null,
+    closedAt: null,
+    author: { login: "a" },
+    reviews: [],
+    comments: [],
+    commits: [],
+    checkSuites: [],
+    timelineItems: [],
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    labels: [],
+  };
+
+  it("calculates ratio", () => {
+    const pr = {
+      ...base,
+      reviews: [
+        { id: "r1", state: "CHANGES_REQUESTED", submittedAt: base.createdAt, author: { login: "a" } },
+        { id: "r2", state: "APPROVED", submittedAt: base.createdAt, author: { login: "b" } },
+      ],
+    };
+    expect(calculateChangeRequestRatio(pr)).toBeCloseTo(0.5);
+  });
+
+  it("throws without reviews", () => {
+    expect(() => calculateChangeRequestRatio(base)).toThrow();
+  });
+});

--- a/test/ciPassRate.test.ts
+++ b/test/ciPassRate.test.ts
@@ -1,0 +1,40 @@
+import { calculateCiPassRate } from "../src/calculators/ciPassRate";
+import { RawPullRequest } from "../src/collectors/pullRequests";
+
+describe("calculateCiPassRate", () => {
+  const base: RawPullRequest = {
+    id: "1",
+    number: 1,
+    title: "t",
+    state: "OPEN",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    mergedAt: null,
+    closedAt: null,
+    author: { login: "a" },
+    reviews: [],
+    comments: [],
+    commits: [],
+    checkSuites: [],
+    timelineItems: [],
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    labels: [],
+  };
+
+  it("computes pass rate", () => {
+    const pr = {
+      ...base,
+      checkSuites: [
+        { id: "1", status: "COMPLETED", conclusion: "SUCCESS", startedAt: base.createdAt, completedAt: base.createdAt },
+        { id: "2", status: "COMPLETED", conclusion: "FAILURE", startedAt: base.createdAt, completedAt: base.createdAt },
+      ],
+    };
+    expect(calculateCiPassRate(pr)).toBeCloseTo(0.5);
+  });
+
+  it("handles absence of check suites", () => {
+    expect(calculateCiPassRate(base)).toBe(0);
+  });
+});

--- a/test/commentDensity.test.ts
+++ b/test/commentDensity.test.ts
@@ -1,0 +1,47 @@
+import { calculateCommentDensity } from "../src/calculators/commentDensity";
+import { RawPullRequest } from "../src/collectors/pullRequests";
+
+describe("calculateCommentDensity", () => {
+  const base: RawPullRequest = {
+    id: "1",
+    number: 1,
+    title: "t",
+    state: "OPEN",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    mergedAt: null,
+    closedAt: null,
+    author: { login: "a" },
+    reviews: [],
+    comments: [],
+    commits: [],
+    checkSuites: [],
+    timelineItems: [],
+    additions: 1,
+    deletions: 1,
+    changedFiles: 1,
+    labels: [],
+  };
+
+  it("computes density", () => {
+    const pr = {
+      ...base,
+      comments: [
+        { id: "c1", body: "a", createdAt: base.createdAt, author: { login: "a" } },
+        { id: "c2", body: "b", createdAt: base.createdAt, author: null },
+      ],
+    };
+    const d = calculateCommentDensity(pr);
+    expect(d).toBeCloseTo(1);
+  });
+
+  it("returns zero when no comments", () => {
+    const pr = { ...base, additions: 5, deletions: 5 };
+    expect(calculateCommentDensity(pr)).toBe(0);
+  });
+
+  it("throws when no line changes", () => {
+    const pr = { ...base, additions: 0, deletions: 0 };
+    expect(() => calculateCommentDensity(pr)).toThrow();
+  });
+});

--- a/test/idleTimeHours.test.ts
+++ b/test/idleTimeHours.test.ts
@@ -1,0 +1,44 @@
+import { calculateIdleTimeHours } from "../src/calculators/idleTimeHours";
+import { RawPullRequest } from "../src/collectors/pullRequests";
+
+describe("calculateIdleTimeHours", () => {
+  const base: RawPullRequest = {
+    id: "1",
+    number: 1,
+    title: "t",
+    state: "MERGED",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-04T00:00:00Z",
+    mergedAt: "2024-01-03T10:00:00Z",
+    closedAt: null,
+    author: { login: "a" },
+    reviews: [],
+    comments: [],
+    commits: [],
+    checkSuites: [],
+    timelineItems: [],
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    labels: [],
+  };
+
+  it("sums idle gaps beyond 24h", () => {
+    const pr = {
+      ...base,
+      commits: [
+        { oid: "c1", messageHeadline: "a", committedDate: "2024-01-02T01:00:00Z", checkSuites: [] },
+        { oid: "c2", messageHeadline: "b", committedDate: "2024-01-03T01:00:00Z", checkSuites: [] },
+      ],
+      reviews: [
+        { id: "r1", state: "APPROVED", submittedAt: "2024-01-03T02:00:00Z", author: { login: "b" } },
+      ],
+    };
+    expect(calculateIdleTimeHours(pr)).toBeCloseTo(1);
+  });
+
+  it("throws when end timestamp missing", () => {
+    const pr = { ...base, mergedAt: null, closedAt: null, updatedAt: undefined as any };
+    expect(() => calculateIdleTimeHours(pr as any)).toThrow();
+  });
+});

--- a/test/revertRate.test.ts
+++ b/test/revertRate.test.ts
@@ -1,0 +1,40 @@
+import { calculateRevertRate } from "../src/calculators/revertRate";
+import { RawPullRequest } from "../src/collectors/pullRequests";
+
+describe("calculateRevertRate", () => {
+  const base: RawPullRequest = {
+    id: "1",
+    number: 1,
+    title: "t",
+    state: "OPEN",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    mergedAt: null,
+    closedAt: null,
+    author: { login: "a" },
+    reviews: [],
+    comments: [],
+    commits: [],
+    checkSuites: [],
+    timelineItems: [],
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    labels: [],
+  };
+
+  it("computes revert ratio", () => {
+    const pr = {
+      ...base,
+      commits: [
+        { oid: "c1", messageHeadline: "revert: fix bug", committedDate: base.createdAt, checkSuites: [] },
+        { oid: "c2", messageHeadline: "add feature", committedDate: base.createdAt, checkSuites: [] },
+      ],
+    };
+    expect(calculateRevertRate(pr)).toBeCloseTo(0.5);
+  });
+
+  it("throws with no commits", () => {
+    expect(() => calculateRevertRate(base)).toThrow();
+  });
+});

--- a/test/reviewerCount.test.ts
+++ b/test/reviewerCount.test.ts
@@ -1,0 +1,46 @@
+import { calculateReviewerCount } from "../src/calculators/reviewerCount";
+import { RawPullRequest } from "../src/collectors/pullRequests";
+
+describe("calculateReviewerCount", () => {
+  const base: RawPullRequest = {
+    id: "1",
+    number: 1,
+    title: "t",
+    state: "OPEN",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    mergedAt: null,
+    closedAt: null,
+    author: { login: "a" },
+    reviews: [],
+    comments: [],
+    commits: [],
+    checkSuites: [],
+    timelineItems: [],
+    additions: 1,
+    deletions: 1,
+    changedFiles: 1,
+    labels: [],
+  };
+
+  it("counts unique reviewers", () => {
+    const pr = {
+      ...base,
+      reviews: [
+        { id: "r1", state: "APPROVED", submittedAt: base.createdAt, author: { login: "a" } },
+        { id: "r2", state: "APPROVED", submittedAt: base.createdAt, author: { login: "b" } },
+        { id: "r3", state: "APPROVED", submittedAt: base.createdAt, author: { login: "a" } },
+        { id: "r4", state: "APPROVED", submittedAt: base.createdAt, author: null },
+      ],
+    };
+    expect(calculateReviewerCount(pr)).toBe(2);
+  });
+
+  it("returns zero for no reviews", () => {
+    expect(calculateReviewerCount(base)).toBe(0);
+  });
+
+  it("throws when reviews missing", () => {
+    expect(() => calculateReviewerCount({ ...(base as any), reviews: undefined as any })).toThrow();
+  });
+});

--- a/test/sizeBucket.test.ts
+++ b/test/sizeBucket.test.ts
@@ -1,0 +1,40 @@
+import { calculateSizeBucket } from "../src/calculators/sizeBucket";
+import { RawPullRequest } from "../src/collectors/pullRequests";
+
+describe("calculateSizeBucket", () => {
+  const base: RawPullRequest = {
+    id: "1",
+    number: 1,
+    title: "t",
+    state: "OPEN",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    mergedAt: null,
+    closedAt: null,
+    author: { login: "a" },
+    reviews: [],
+    comments: [],
+    commits: [],
+    checkSuites: [],
+    timelineItems: [],
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    labels: [],
+  };
+
+  it("returns S for small PRs", () => {
+    const pr = { ...base, additions: 10 };
+    expect(calculateSizeBucket(pr)).toBe("S");
+  });
+
+  it("returns M for medium PRs", () => {
+    const pr = { ...base, additions: 100 };
+    expect(calculateSizeBucket(pr)).toBe("M");
+  });
+
+  it("returns L for large PRs", () => {
+    const pr = { ...base, additions: 500 };
+    expect(calculateSizeBucket(pr)).toBe("L");
+  });
+});


### PR DESCRIPTION
## Summary
- add calculators for reviewer count, comment density, CI pass rate
- add PR size bucket calculation
- add change request ratio, revert rate and idle time metrics
- test the new calculators

## Testing
- `pnpm test`
- `CI=true pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684e3fc0b664833083c6d340097584a9