### PR TITLE
Add weekly metrics workflow

### DIFF
--- a/.github/workflows/weekly-metrics.yml
+++ b/.github/workflows/weekly-metrics.yml
@@ -1,41 +1,21 @@
 name: Weekly Metrics
-
 on:
-  schedule:
-    - cron: "0 8 * * FRI"
-
+  schedule: [{ cron: '0 8 * * FRI' }]
 jobs:
   metrics:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
-        with:
-          version: 9
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: "pnpm"
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run build
-      - run: node dist/cli.js ${{ secrets.TARGET_REPO }} --format json > metrics.json
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
       - run: |
-          mv metrics.json gh-pages/metrics.json
-          cd gh-pages
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          git add metrics.json
-          git commit -m "Update metrics" || true
-      - name: Push metrics
-        uses: ad-m/github-push-action@v0.6.0
+          npx gh-pr-metrics ${{ secrets.METRICS_OWNER }}/${{ secrets.METRICS_REPO }} \
+            --since 7d --format json --use-cache --resume \
+            --token ${{ secrets.GH_TOKEN }} > metrics.json
+      - name: Commit metrics
+        uses: EndBug/add-and-commit@v9
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          directory: gh-pages
-          force: true
+          add: 'metrics.json'
+          message: 'chore(metrics): weekly auto-update'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- replace weekly workflow with latest metrics automation

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684e51e6b4cc83309293c31e22cd0c12