### PR TITLE
Add Slack posting script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@typescript-eslint/parser": "^8.34.0",
     "eslint": "^8.57.1",
     "jest": "^30.0.0",
+    "jest-fetch-mock": "^3.0.3",
     "nock": "^14.0.5",
     "prettier": "^3.5.3",
     "semantic-release": "^24.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       jest:
         specifier: ^30.0.0
         version: 30.0.0(@types/node@20.19.0)
+      jest-fetch-mock:
+        specifier: ^3.0.3
+        version: 3.0.3
       nock:
         specifier: ^14.0.5
         version: 14.0.5
@@ -1317,6 +1320,9 @@ packages:
       typescript:
         optional: true
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2005,6 +2011,9 @@ packages:
     resolution: {integrity: sha512-sF6lxyA25dIURyDk4voYmGU9Uwz2rQKMfjxKnDd19yk+qxKGrimFqS5YsPHWTlAVBo+YhWzXsqZoaMzrTFvqfg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-fetch-mock@3.0.3:
+    resolution: {integrity: sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==}
+
   jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2340,6 +2349,15 @@ packages:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -2649,6 +2667,9 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  promise-polyfill@8.3.0:
+    resolution: {integrity: sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==}
 
   propagate@2.0.1:
     resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
@@ -2984,6 +3005,9 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   traverse@0.6.8:
     resolution: {integrity: sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==}
     engines: {node: '>= 0.4'}
@@ -3144,6 +3168,12 @@ packages:
 
   weapon-regex@1.3.2:
     resolution: {integrity: sha512-jtFTAr0F3gmiX10J6+BYgPrZ/yjXhpcxK/j/Lm1fWRLATxfecPgnkd3DqSUkD0AC2wVVyAkMtsgeuiIuELlW3w==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4759,6 +4789,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5536,6 +5572,13 @@ snapshots:
       jest-util: 30.0.0
       jest-validate: 30.0.0
 
+  jest-fetch-mock@3.0.3:
+    dependencies:
+      cross-fetch: 3.2.0
+      promise-polyfill: 8.3.0
+    transitivePeerDependencies:
+      - encoding
+
   jest-get-type@29.6.3: {}
 
   jest-haste-map@30.0.0:
@@ -5968,6 +6011,10 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-int64@0.4.0: {}
 
   node-releases@2.0.19: {}
@@ -6176,6 +6223,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
+
+  promise-polyfill@8.3.0: {}
 
   propagate@2.0.1: {}
 
@@ -6546,6 +6595,8 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
+  tr46@0.0.3: {}
+
   traverse@0.6.8: {}
 
   tree-kill@1.2.2: {}
@@ -6687,6 +6738,13 @@ snapshots:
       makeerror: 1.0.12
 
   weapon-regex@1.3.2: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:

--- a/scripts/postToSlack.ts
+++ b/scripts/postToSlack.ts
@@ -1,0 +1,49 @@
+import fs from 'fs';
+
+export async function postToSlack(metricsPath = './metrics.json') {
+  const data = JSON.parse(fs.readFileSync(metricsPath, 'utf8'));
+
+  const medianCycleTimeHours = data.medianCycleTimeHours;
+  const p95PickupTimeHours = data.p95PickupTimeHours;
+  const largePrRatio = data.largePrRatio;
+
+  const blocks = [
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `*Median cycle time\n${medianCycleTimeHours}h` },
+        { type: 'mrkdwn', text: `*p95 pickup time\n${p95PickupTimeHours}h` },
+        { type: 'mrkdwn', text: `*Large PR ratio\n${(largePrRatio * 100).toFixed(1)}%` },
+      ],
+    },
+  ];
+
+  const webhook = process.env['SLACK_WEBHOOK_URL'];
+  if (!webhook) {
+    console.error('SLACK_WEBHOOK_URL not set');
+    return false;
+  }
+
+  try {
+    const res = await fetch(webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ blocks }),
+    });
+    if (!res.ok) {
+      console.error(`Slack POST failed: ${res.status}`);
+      return false;
+    }
+    console.log('Posted to Slack');
+    return true;
+  } catch (err) {
+    console.error(`Slack POST failed: ${(err as Error).message}`);
+    return false;
+  }
+}
+
+export default postToSlack;
+
+if (process.argv[1] && process.argv[1].endsWith('postToSlack.js')) {
+  postToSlack(process.argv[2]).then((ok) => process.exit(ok ? 0 : 1));
+}

--- a/test/scripts/postToSlack.test.ts
+++ b/test/scripts/postToSlack.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+import fetchMock from 'jest-fetch-mock';
+import { postToSlack } from '../../scripts/postToSlack';
+
+fetchMock.enableMocks();
+
+const origEnv = process.env;
+
+describe('postToSlack script', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    process.env = { ...origEnv, SLACK_WEBHOOK_URL: 'https://example.com/webhook' };
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it('posts metrics to slack', async () => {
+    const tmp = fs.mkdtempSync(path.join(process.cwd(), 'metrics-'));
+    const metrics = {
+      medianCycleTimeHours: 5,
+      p95PickupTimeHours: 10,
+      largePrRatio: 0.2,
+    };
+    const file = path.join(tmp, 'm.json');
+    fs.writeFileSync(file, JSON.stringify(metrics));
+
+    await postToSlack(file);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://example.com/webhook');
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    expect(body).toEqual({
+      blocks: [
+        {
+          type: 'section',
+          fields: [
+            { type: 'mrkdwn', text: '*Median cycle time\n5h' },
+            { type: 'mrkdwn', text: '*p95 pickup time\n10h' },
+            { type: 'mrkdwn', text: '*Large PR ratio\n20.0%' },
+          ],
+        },
+      ],
+    });
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add `postToSlack` script for posting metrics to Slack
- mock fetch using `jest-fetch-mock` and add unit test
- include `jest-fetch-mock` dev dependency

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ebeb71ba48330aa349d94430b01ae