### PR TITLE
Add Slack notification to weekly metrics workflow

### DIFF
--- a/.github/workflows/weekly-metrics.yml
+++ b/.github/workflows/weekly-metrics.yml
@@ -19,3 +19,7 @@ jobs:
           message: 'chore(metrics): weekly auto-update'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Send Slack summary
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: node scripts/postToSlack.js --file metrics.json


### PR DESCRIPTION
## Summary
- run scripts/postToSlack.js after committing metrics

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a895d1008330ad7b5157aa4b274d